### PR TITLE
Ajustando para exportar o InAppWidget para fora da lib

### DIFF
--- a/lib/inngage_plugin.dart
+++ b/lib/inngage_plugin.dart
@@ -16,4 +16,4 @@ export 'util/hexcolor.dart';
 export 'util/utils.dart';
 export 'inngage_sdk.dart';
 export 'inapp/inngage_inapp.dart';
-
+export 'inapp/inapp_widget.dart';


### PR DESCRIPTION
No VSCode nao estava encontrando a referencia para a importaçao da classe de InAppWidget.